### PR TITLE
Fix MetaArgEngine bug when cp.Optional.Eq(True)

### DIFF
--- a/facto/inputgen/argument/engine.py
+++ b/facto/inputgen/argument/engine.py
@@ -227,6 +227,12 @@ class MetaArgEngine:
         )
         return True in engine.gen(Attribute.OPTIONAL, self.deps)
 
+    def gen_only_null(self):
+        engine = AttributeEngine(
+            Attribute.OPTIONAL, self.constraints, self.valid, self.argtype
+        )
+        return engine.gen(Attribute.OPTIONAL, self.deps) == [True]
+
     def gen_scalars(self, scalar_dtype, focus):
         engine = AttributeEngine(
             Attribute.VALUE, self.constraints, self.valid, self.argtype, scalar_dtype
@@ -262,6 +268,10 @@ class MetaArgEngine:
                 raise NotImplementedError("Tensor List output not implemented yet")
             else:
                 raise ValueError("Output argtype must be tensor or tensor list")
+
+        if self.gen_only_null():
+            yield MetaArg(self.argtype, optional=True)
+            return
 
         if focus in [None, Attribute.OPTIONAL]:
             if self.argtype.is_optional() and self.gen_optional():

--- a/test/inputgen/test_attribute_engine.py
+++ b/test/inputgen/test_attribute_engine.py
@@ -57,6 +57,31 @@ class TestAttributeEngine(unittest.TestCase):
         values = engine.gen(Attribute.VALUE)
         self.assertTrue(len(values) == 0)
 
+    def test_optional(self):
+        engine = AttributeEngine(
+            Attribute.OPTIONAL, [cp.Optional.Eq(lambda: True)], True, ArgType.IntOpt
+        )
+        values = engine.gen(Attribute.OPTIONAL)  # focus is OPTIONAL
+        self.assertEqual(values, [True])
+
+        engine = AttributeEngine(
+            Attribute.OPTIONAL, [cp.Optional.Eq(lambda: False)], True, ArgType.IntOpt
+        )
+        values = engine.gen(Attribute.OPTIONAL)  # focus is OPTIONAL
+        self.assertEqual(values, [False])
+
+        engine = AttributeEngine(
+            Attribute.OPTIONAL, [cp.Optional.Eq(lambda: True)], True, ArgType.IntOpt
+        )
+        values = engine.gen(Attribute.VALUE)  # focus is VALUE
+        self.assertEqual(values, [True])
+
+        engine = AttributeEngine(
+            Attribute.OPTIONAL, [cp.Optional.Eq(lambda: False)], True, ArgType.IntOpt
+        )
+        values = engine.gen(Attribute.VALUE)  # focus is VALUE
+        self.assertEqual(values, [False])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/inputgen/test_attribute_solver.py
+++ b/test/inputgen/test_attribute_solver.py
@@ -78,6 +78,21 @@ class TestAttributeSolver(unittest.TestCase):
         variables = list(solver.solve(constraints, Attribute.VALUE, False))
         self.assertEqual(len(variables), 0)
 
+    def test_optional(self):
+        solver = AttributeSolver(Attribute.OPTIONAL, ArgType.IntOpt)
+        constraints = [cp.Optional.Eq(lambda: True)]
+
+        variables = list(solver.solve(constraints, Attribute.OPTIONAL, True))
+        self.assertEqual(len(variables), 1)
+        self.assertEqual(str(variables[0].space), "{True}")
+
+        solver = AttributeSolver(Attribute.OPTIONAL, ArgType.IntOpt)
+        constraints = [cp.Optional.Eq(lambda: False)]
+
+        variables = list(solver.solve(constraints, Attribute.OPTIONAL, True))
+        self.assertEqual(len(variables), 1)
+        self.assertEqual(str(variables[0].space), "{False}")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/inputgen/test_meta_arg_engine.py
+++ b/test/inputgen/test_meta_arg_engine.py
@@ -65,6 +65,21 @@ class TestMetaArgEngine(unittest.TestCase):
         self.assertTrue(1 <= len(ms[0].value) <= 5)
         self.assertTrue(all(v == 3 for v in ms[0].value))
 
+    def test_optional_int(self):
+        constraints = [cp.Optional.Eq(lambda deps: True)]
+        deps = []
+        outarg = False
+
+        engine = MetaArgEngine(outarg, ArgType.IntOpt, constraints, deps, True)
+        ms = list(engine.gen(Attribute.OPTIONAL))  # focus is OPTIONAL
+        self.assertEqual(len(ms), 1)
+        self.assertEqual(str(ms[0]), "ArgType.IntOpt None")
+
+        engine = MetaArgEngine(outarg, ArgType.IntOpt, constraints, deps, True)
+        ms = list(engine.gen(Attribute.VALUE))  # focus is VALUE
+        self.assertEqual(len(ms), 1)
+        self.assertEqual(str(ms[0]), "ArgType.IntOpt None")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
MetaArgEngine didn't respect an Optional = True constraint, when generating a MetaArg with focus on an Attribute other than OPTIONAL. This PR fixes that bug, and adds testing for this at different levels

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #51
* #50
* #49
* #48
* #47
* #46
* __->__ #45

Differential Revision: [D80634938](https://our.internmc.facebook.com/intern/diff/D80634938)