### PR TITLE
[EZ] Replace `pytorch-labs` with `meta-pytorch`

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ SpecDB is a [database](facto/specdb/db.py#L30) of specifications covering most o
 
 ## Instalation
 ```bash
-git clone https://github.com/pytorch-labs/FACTO.git
+git clone https://github.com/meta-pytorch/FACTO.git
 cd FACTO
 pip install .
 ```
@@ -53,7 +53,7 @@ Calibrator is under development. It is intended to be a tool for calibrating the
 ## Reporting problems
 
 If you encounter a bug or some other problem with FACTO, please file an issue on
-https://github.com/pytorch-labs/facto/issues.
+https://github.com/meta-pytorch/facto/issues.
 
 ## License
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/pytorch-labs/FACTO"
+Homepage = "https://github.com/meta-pytorch/FACTO"
 
 [tool.setuptools.packages.find]
 include = ["facto", "facto.*"]


### PR DESCRIPTION
This PR replaces all instances of `pytorch-labs` with `meta-pytorch` in this repository now that the `pytorch-labs` org has been renamed to `meta-pytorch`

## Changes Made
- Replaced all occurrences of `pytorch-labs` with `meta-pytorch`
- Skipped binary files and files larger than 1MB due to GitHub api payload limits in the script to cover all repos in this org. Will do a more manual second pass later to cover any larger files

## Files Modified
This PR updates files that contained the target text.

Generated by automated script on 2025-08-22T23:26:56.426391+00:00Z