### PR TITLE
typos: fix Instalation to Installation and other typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Here is an [overview](facto/inputgen/overview.md) of InputGen
 
 SpecDB is a [database](facto/specdb/db.py#L30) of specifications covering most of the Core ATen Ops. They have been developed using the ATen CPU kernels as a reference.
 
-## Instalation
+## Installation
 ```bash
 git clone https://github.com/meta-pytorch/FACTO.git
 cd FACTO

--- a/facto/inputgen/argtuple/engine.py
+++ b/facto/inputgen/argtuple/engine.py
@@ -11,11 +11,11 @@ from facto.inputgen.specs.model import Spec
 
 
 def reverse_topological_sort(graph):
-    def dfs(node, visited, strack):
+    def dfs(node, visited, stack):
         visited[node] = True
         for neig in graph[node]:
             if not visited[neig]:
-                dfs(neig, visited, strack)
+                dfs(neig, visited, stack)
         stack.append(node)
 
     visited = {node: False for node in graph}

--- a/facto/inputgen/overview.md
+++ b/facto/inputgen/overview.md
@@ -38,7 +38,7 @@ An argument of an op might depend on another argument. For example, an argument 
 ### Constraints
 
 A given constraint has 3 parts: an attribute, a suffix and a lambda function.
-We already went through the attributes. The suffix is a basic operation, like Equal (Eq), Not Equal (Ne), Less than (Lt), Greather than (Gt), etc.
+We already went through the attributes. The suffix is a basic operation, like Equal (Eq), Not Equal (Ne), Less than (Lt), Greater than (Gt), etc.
 The lambda function takes the dependencies (other arguments) as inputs, and outputs certain value. The constraint should then be read as: attribute suffix value. For example, if the attribute is Length, and suffix is Gt, and the lambda function outputs 4, then the constraint is saying that the Length > 4.
 
 ## Generation

--- a/facto/inputgen/variable/space.py
+++ b/facto/inputgen/variable/space.py
@@ -19,7 +19,7 @@ from facto.inputgen.variable.type import (
 
 class Discrete:
     """
-    Representes a set of discrete values. Examples:
+    Represents a set of discrete values. Examples:
 
     >>> d = Discrete(['a','b','c'])
     >>> d.contains('a')
@@ -149,9 +149,9 @@ class Interval:
         self.upper_open = upper_open
 
     def __str__(self) -> str:
-        lower_braket = "(" if self.lower_open else "["
-        upper_braket = ")" if self.upper_open else "]"
-        return f"{lower_braket}{self.lower}, {self.upper}{upper_braket}"
+        lower_bracket = "(" if self.lower_open else "["
+        upper_bracket = ")" if self.upper_open else "]"
+        return f"{lower_bracket}{self.lower}, {self.upper}{upper_bracket}"
 
     def __eq__(self, other: "Interval") -> bool:
         return (
@@ -337,7 +337,7 @@ class Intervals:
 
     def set_upper(self, upper: Union[int, float], upper_open: bool = False) -> None:
         """Sets the upper bound, being open or closed depending on the flag. In other
-        words, it removes all values greather than the given value. It also removes the value
+        words, it removes all values greater than the given value. It also removes the value
         itself if upper_open is True."""
         for ix, r in enumerate(self.intervals):
             if r.upper < upper:


### PR DESCRIPTION
Fix some typos
`Instalation` -> `Installation`
`strack` -> `stack`
`Greather` -> `Greater`
`Representes` -> `Represents`
`braket` -> `bracket`